### PR TITLE
fix industry production

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -51,4 +51,10 @@ vm_cesIO.lo(t,regi_dyn29(regi),in_industry_dyn37(in))$(
                                                   0 eq vm_cesIO.lo(t,regi,in) )
   = sm_eps;
 
+!! Fix industry output for bal scenario
+$ifthen.bal_scenario "%cm_import_EU%" == "bal"   !! cm_import_EU
+  vm_cesIO.fx(t,regi,in)$( p37_industry_quantity_targets(t,regi,in) )
+  = p37_industry_quantity_targets(t,regi,in);
+$endif.bal_scenario
+
 *** EOF ./modules/37_industry/subsectors/bounds.gms

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -165,6 +165,52 @@ Table pm_calibrate_eff_scale(all_in,all_in,eff_scale_par)   "parameters for scal
 ;
 $offtext
 
+$ifthen.bal_scenario "%cm_import_EU%" == "bal"   !! cm_import_EU
+  Parameter
+    p37_industry_quantity_targets(ttot,all_regi,all_in)   "quantity targets for industry in policy scenarios"
+    !! from FORECAST v1.0_8Gt_Bal.xlsx
+    /
+      2020 . DEU . ue_cement   34.396171
+      2025 . DEU . ue_cement   34.086007
+      2030 . DEU . ue_cement   33.497825
+      2035 . DEU . ue_cement   32.984228
+      2040 . DEU . ue_cement   32.517921
+      2045 . DEU . ue_cement   31.826778
+      2050 . DEU . ue_cement   31.13703
+  
+      2020 . DEU . ue_steel_primary     25.07355
+      2025 . DEU . ue_steel_primary     27.08212
+      2030 . DEU . ue_steel_primary     24.808956
+      2035 . DEU . ue_steel_primary     22.442278
+      2040 . DEU . ue_steel_primary     20.219831
+      2045 . DEU . ue_steel_primary     19.946714
+      2050 . DEU . ue_steel_primary     19.725106
+  
+      2020 . DEU . ue_steel_secondary   10.50795
+      2025 . DEU . ue_steel_secondary   14.288815
+      2030 . DEU . ue_steel_secondary   16.181637
+      2035 . DEU . ue_steel_secondary   18.103032
+      2040 . DEU . ue_steel_secondary   20.168031
+      2045 . DEU . ue_steel_secondary   19.946714
+      2050 . DEU . ue_steel_secondary   19.725106
+    /
+  ;
+  
+  !! convert Mt to Gt
+  p37_industry_quantity_targets(t,regi,in)$(
+                                      p37_industry_quantity_targets(t,regi,in) )
+    = p37_industry_quantity_targets(t,regi,in)
+      !! Mt/yr * 1e-3 Gt/Mt = Gt/yr
+    * 1e-3;
+  
+  !! extend beyond 2050
+  !! FIXME: do this smarter, using something like GDPpC growth or something
+  p37_industry_quantity_targets(t,regi,in)$(
+                                 p37_industry_quantity_targets("2050",regi,in)
+ 	                     AND t.val ge 2050                                 )
+    = p37_industry_quantity_targets("2050",regi,in);
+$endif.bal_scenario
+
 pm_calibrate_eff_scale("feelhth_chemicals","fega_chemicals","level")     = 1.5;
 pm_calibrate_eff_scale("feelhth_chemicals","fega_chemicals","midperiod") = 2030;
 pm_calibrate_eff_scale("feelhth_chemicals","fega_chemicals","width")     = 15;


### PR DESCRIPTION
Fix industry productions ue_cement, ue_steel_primary, and ue_steel_secondary to exogenous FORECAST trajectories for scenarios with cm_import_EU = "bal"

- Data from `FORECAST v1.0_8Gt_Bal.xlsx` is hardcoded in `subsectors/datainput.gdx`, but can be factored out to an additional file or `mrremind` later on.  
- Data is kept constant after 2050.  This can be improved by keeping specific production per capita or per GDP constant instead.
- `vm_cesIO` is fixed to those values if `cm_import_EU` is set to `bal`.  (Seemed to be an easy way to discern different scenarios can be modified of course).
- Local `testOneRegi` run on `DEU` was successful.


- [x] New feature 

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
