### PR TITLE
Add biomass constraint in industry subsectors and use it to limit biomass use in steel sector

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -428,4 +428,10 @@ execute_load "input_ref.gdx", vm_demFEsector;
     );
 );
 
+
+
+*** FS: maximum share of biomass use in industry subsector
+*** set to prevent too fast or technically unrealistic switch to biomass in industry subsectors
+p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)=1;
+
 *** EOF ./modules/37_industry/subsectors/datainput.gms

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -438,7 +438,7 @@ p37_BioShareMaxSubsec(t,regi,entyFeCC37,secInd37)=1;
 
 
 *** for steel set maximum biomass share in solids to 30% until 2025 and linearly increase up to 80% in 2050
-p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val le 2025)=0.3;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2015 AND t.val le 2025)=0.3;
 p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2025 AND t.val le 2050)= 0.3 + (t.val - 2025) * 0.02;
 p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2050)=p37_BioShareMaxSubsec("2050",regi,"fesos","steel");
 

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -432,6 +432,18 @@ execute_load "input_ref.gdx", vm_demFEsector;
 
 *** FS: maximum share of biomass use in industry subsector
 *** set to prevent too fast or technically unrealistic switch to biomass in industry subsectors
-p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)=1;
+
+*** initialize maximum biomass share in all industry subsectors at 100%
+p37_BioShareMaxSubsec(t,regi,entyFeCC37,secInd37)=1;
+
+
+*** for steel set maximum biomass share in solids to 30% until 2025 and linearly increase up to 80% in 2050
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val le 2025)=0.3;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2025 AND t.val le 2050)= 0.3 + (t.val - 2025) * 0.02;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2050)=p37_BioShareMaxSubsec("2050",regi,"fesos","steel");
+
+*** for Germany set maximum biomass share of solids in steel to 10% at all times
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val ge 2020 AND sameas(regi,"DEU"))=0.1;
+
 
 *** EOF ./modules/37_industry/subsectors/datainput.gms

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -22,6 +22,7 @@ Parameters
   p37_steel_secondary_max_share(tall,all_regi)                                 "maximum share of secondary steel production"
   p37_BAU_industry_ETS_solids(tall,all_regi)                                   "industry solids demand in baseline scenario"
   p37_cesIO_baseline(tall,all_regi,all_in)                                     "vm_cesIO from the baseline scenario"
+  p37_BioShareMaxSubsec(ttot,all_regi,all_enty,secInd37)                       "maximum biomass share in industry subsector per energy carrier"
 
 *** output parameters only for reporting
   o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                   "industry CCS emissions [GtC/a]"                                                                                
@@ -58,6 +59,7 @@ Equations
   q37_IndCCSCost                                          "Calculate industry CCS costs"
   q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)       "industry final energy demand (per emission market)"
   q37_costCESmarkup(ttot,all_regi,all_in)                 "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
+  q37_BioLimitSubsec(ttot,all_regi,all_enty,all_emiMkt)   "limits of switching to biomass use in industry subsectors"
 ;
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -142,4 +142,19 @@ q37_costCESmarkup(t,regi,in)$(ppfen_industry_dyn37(in))..
   * (vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
 
+*** limits of switching to biomass use in industry subsectors
+q37_BioLimitSubsec(t,regi,entyFe,emiMkt)..
+  sum( se2fe(entySeBio,entyFe,te),
+    vm_demFEsector(t,regi,entySeBio,entyFE,"indst",emiMkt)
+  )
+  =l=
+  sum(secInd37_emiMkt(secInd37,emiMkt),
+      p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)
+      * sum( (secInd37_2_pf(secInd37,in),
+              fe2ppfen37(entyFe,in)),
+          vm_cesIO(t,regi,in))
+  )
+;
+
+
 *** EOF ./modules/37_industry/subsectors/equations.gms


### PR DESCRIPTION
This adds a constraint to the industry module that limits the maximum amount of biomass to be demanded by industry based on assumptions in the parameter ``p37_BioShareMaxSubsec``. The parameter determines how much biomass can be used in a certain subsector (steel, cement, chemicals, other industry). This maximum biomass share per subsector can be changed over time allowing for more restrictive biomass switching in early years. 

We make the following assumptions:

By default: max. 30% biomass in steel solids (2025) to 80% (after 2050)
In Germany: only max. 10% biomass in steel solids for all times
